### PR TITLE
Post-Pilot Updates for OpenMP Episodes

### DIFF
--- a/high_performance_computing/hpc_openmp/02_intro_openmp.md
+++ b/high_performance_computing/hpc_openmp/02_intro_openmp.md
@@ -11,7 +11,8 @@ learningOutcomes:
 
 ## What is OpenMP?
 
-OpenMP is an industry-standard API specifically designed for parallel programming in shared memory environments. It supports programming in languages such as C, C++, and Fortran. OpenMP is an open source, industry-wide initiative that benefits from collaboration among hardware and software vendors, governed by the OpenMP Architecture Review Board ([OpenMP ARB](https://www.openmp.org/)).
+OpenMP is an industry-standard API specifically designed for parallel programming in shared memory environments. It supports programming in languages such as C, C++, 
+and Fortran. OpenMP is an open source, industry-wide initiative that benefits from collaboration among hardware and software vendors, governed by the OpenMP Architecture Review Board ([OpenMP ARB](https://www.openmp.org/)).
 
 ::::challenge{id=timeline, title="An OpenMP Timeline"}
 
@@ -35,16 +36,17 @@ OpenMP consists of three key components that enable parallel programming using t
 
 - **Compiler Directives:** OpenMP makes use of special code markers known as *compiler directives* to indicate to the compiler when and how to parallelise various sections of code. These directives are prefixed with `#pragma omp`, and mark sections of code to be executed concurrently by multiple threads.
 - **Runtime Library Routines:** These are predefined functions provided by the OpenMP runtime library. They allow you to control the behavior of threads, manage synchronisation, and handle parallel execution. For example, we can use the function `omp_get_thread_num()` to obtain the unique identifier of the calling thread.
-- **Environment Variables:** These are settings that can be adjusted to influence the behavior of the OpenMP runtime. They provide a way to fine-tune the parallel execution of your program. Setting OpenMP environment variables is typically done similarly to other environment variables for your system. For instance, you can adjust the number of threads to use for a program you are about to execute by specifying the value in the `OMP_NUM_THREADS` environment variable.
+- **Environment Variables:** These are settings that can be adjusted to influence the behavior of the OpenMP runtime. They provide a way to fine-tune the parallel execution of your program. Setting OpenMP environment variables is typically done similarly to other environment variables for your system. 
+For instance, you can adjust the number of threads to use for a program you are about to execute by specifying the value in the `OMP_NUM_THREADS` environment variable.
 
 Since parallelisation using OpenMP is accomplished by adding compiler directives to existing code structures, it's relatively easy to get started using it.
 This also means it's straightforward to use on existing code, so it can prove a good approach to migrating serial code to parallel.
-Since OpenMP support is built into existing compilers, it's also a defacto standard for C parallel programming.
-However, it's worth noting that other options exist in different languages (e.g. there are c++many options in C++, the [multiprocessing library](https://docs.python.org/3/library/multiprocessing.html) for Python, [Rayon](https://docs.rs/rayon/latest/rayon/) for Rust).
+Since OpenMP support is built into existing compilers, it's also a de facto standard for C parallel programming.
+However, it's worth noting that other options exist in different languages (e.g. there are many options in C++, the [multiprocessing library](https://docs.python.org/3/library/multiprocessing.html) for Python, [Rayon](https://docs.rs/rayon/latest/rayon/) for Rust).
 
 ## Running a Code with OpenMP
 
-Before we get into into specifics of writing code that uses OpenMP, let's first look at how we compile and run an example "Hello World!" OpenMP program that prints this to the console.
+Before we get into specifics of writing code that uses OpenMP, let's first look at how we compile and run an example "Hello World!" OpenMP program that prints this to the console.
 
 Wherever you may eventually run your OpenMP code - locally, on another machine, or on an HPC infrastructure - it's a good practice to develop OpenMP programs on your local machine first.
 This has the advantage of allowing you to more easily configure your development environment to suit your needs, particularly for making use of tools like Integrated Development Environments (IDEs), such as Microsoft VSCode.
@@ -63,8 +65,15 @@ int main() {
     }
 }
 ~~~
+:::callout{variant="note"}
+In this example, `#include <omp.h>` is not strictly necessary since the code does 
+not call OpenMP runtime functions. However, it is a good practice to include this header to make it clear that 
+the program uses OpenMP and to prepare for future use of OpenMP library functions.
+:::
 
-You'll likely want to compile it using a standard compiler such as `gcc`, although this may depend on your system. To enable the creation of multi-threaded code based on OpenMP directives, pass the `-fopenmp` flag to the compiler. This flag indicates that you're compiling an OpenMP program:
+You'll likely want to compile it using a standard compiler such as `gcc`, although this may depend on your 
+system. To enable the creation of multi-threaded code based on OpenMP directives, pass the `-fopenmp` flag to the compiler. 
+This flag indicates that you're compiling an OpenMP program:
 
 ~~~bash
 gcc hello_world_omp.c -o hello_world_omp -fopenmp

--- a/high_performance_computing/hpc_openmp/04_synchronisation.md
+++ b/high_performance_computing/hpc_openmp/04_synchronisation.md
@@ -34,7 +34,7 @@ Synchronisation is also important for data dependency, to make sure that a threa
 This is particularly important for algorithms which are iterative.
 
 The synchronisation mechanisms in OpenMP are incredibly important tools, as they are used to avoid race conditions. Race
-conditions are have to be avoided, otherwise they *can* result in data inconsistencies if we have any in our program. A
+conditions have to be avoided, otherwise they *can* result in data inconsistencies if we have any in our program. A
 race  condition happens when two, or more, threads access and modify the same piece of data at the same time. To
 illustrate this, consider the diagram below:
 
@@ -46,10 +46,10 @@ can't actually guarantee what it will be. If both threads access and modify the 
 final value will be 1. That's because both variables read the initial value of 0, increment it by 1, and write to the
 shared variable.
 
-In this case, it doesn't matter if the variable update does or doesn't happen concurrently. The inconsistency stems from
+In this case, it doesn't matter if the variable update does or does not happen concurrently. The inconsistency stems from
 the value initially read by each thread. If, on the other hand, one thread manages to access and modify the variable
-before the other thread can read its value, then we'll get the value we expect (2). For example, if thead 0 increments
-the variable before thread 1 reads it, then thread 1 will read a value of 1 and increment that by 1 givusing us the
+before the other thread can read its value, then we'll get the value we expect (2). For example, if thread 0 increments
+the variable before thread 1 reads it, then thread 1 will read a value of 1 and increment that by 1 giving us the
 correct value of 2. This illustrates why it's called a race condition, because threads race each other to access and
 modify variables before another thread can!
 
@@ -91,7 +91,7 @@ int main(void) {
 
 :::solution
 What you will notice is that when you run the program, the final value changes each time. The correct final value is
-10,000 but you will often get a value that is lower than this. This is caused by a race condition, as explained in
+10,000, but you will often get a value that is lower than this. This is caused by a race condition, as explained in
 the previous diagram where threads are incrementing the value of `value` before another thread has finished with it.
 
 So the race condition is in the parallel loop and happens because of threads reading the value of `value` before it
@@ -109,11 +109,11 @@ potentially limit access to tasks or data to certain threads.
 
 ### Barriers
 
-Barriers are a the most basic synchronisation mechanism. They are used to create a waiting point in our program. When a
+Barriers are the most basic synchronisation mechanism. They are used to create a waiting point in our program. When a
 thread reaches a barrier, it waits until all other threads have reached the same barrier before continuing. To add a
 barrier, we use the `#pragma omp barrier` directive. In the example below, we have used a barrier to synchronise threads
-such that they don't start the main calculation of the program until a look up table has been initialised (in parallel),
-as the calculation depends on this data.
+such that they don't start the main calculation of the program until a look-up table has been initialised (in parallel),
+as the calculation depends on this data (See the full code [here](code/examples/04-barriers.c)).
 
 ```c
 #pragma omp parallel
@@ -125,28 +125,42 @@ as the calculation depends on this data.
 
     #pragma omp barrier  /* As all threads depend on the table, we have to wait until all threads
                             are done and have reached the barrier */
-
+    
+    /* Each thread then proceeds to its main calculation */
     do_main_calculation(thread_id);
 }
 ```
-
-We can also put a barrier into a parallel for loop. In the next example, a barrier is used to ensure that the
-calculation for `new_matrix` is done before it is copied into `old_matrix`.
+Similarly, in iterative tasks like matrix calculations, barriers help coordinate threads so that all updates 
+are finished before moving to the next step. For example, in the following snippet, a barrier makes sure that updates 
+to `new_matrix` are completed before it is copied into `old_matrix`:
 
 ```c
-double old_matrix[NX][NY];
-double new_matrix[NX][NY];
+......
+int main() {
+    double old_matrix[NX][NY];
+    double new_matrix[NX][NY];
 
-#pragma omp parallel for
-for (int i = 0; i < NUM_ITERATIONS; ++i) {
-    int thread_id = omp_get_thread_num();
-    iterate_matrix_solution(old_matrix, new_matrix, thread_id);
-    
-    #pragma omp barrier  /* You may want to wait until new_matrix has been updated by all threads */
-    
-    copy_matrix(new_matrix, old_matrix);
+    #pragma omp parallel
+    {
+        for (int i = 0; i < NUM_ITERATIONS; ++i) {
+            int thread_id = omp_get_thread_num();
+
+            iterate_matrix_solution(old_matrix, new_matrix, thread_id); /* Each thread updates a portion of the matrix */
+
+            #pragma omp barrier /* You may want to wait until new_matrix has been updated by all threads */
+
+            copy_matrix(new_matrix, old_matrix);
+        }
+    }
 }
+
 ```
+:::callout{variant='note'}
+OpenMP does not allow barriers to be placed directly inside `#pragma omp parallel for` loops due to restrictions 
+on closely [nested regions](https://www.openmp.org/spec-html/5.2/openmpse101.html#x258-27100017.1). To coordinate threads 
+effectively in iterative tasks like this, the loop has been rewritten using a `#pragma omp parallel` construct with 
+explicit loop control. You can find the full code for this example [here](code/examples/04-matrix-update.c).
+:::
 
 Barriers introduce additional overhead into our parallel algorithms, as some threads will be idle whilst waiting for
 other threads to catch up. There is no way around this synchronisation overhead, so we need to be careful not to overuse
@@ -191,15 +205,15 @@ which are used to prevent multiple threads from executing the same piece of code
 one of these regions, they queue up and wait their turn to access the data and execute the code within the region. The
 table below shows the types of synchronisation region in OpenMP.
 
-| Region | Description | Directive |
-| - | - | - |
+| Region       | Description                                                                                                                                                                                                                                                                                    | Directive              |
+|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------|
 | **critical** | Only one thread is allowed in the critical region. Threads have to queue up to take their turn. When one thread is finished in the critical region, it proceeds to execute the next chunk of code (not in the critical region) immediately without having to wait for other threads to finish. | `#pragma omp critical` |
-| **single** | Single regions are used for code which needs to be executed only by a single thread, such as for I/O operations. The first thread to reach the region will execute the code, whilst the other threads will behave as if they've reached a barrier until the executing thread is finished. | `#pragma omp single` |
-| **master** | A master region is identical to the single region other than that execution is done by the designated master thread (usually thread 0). | `#pragma omp master` |
+| **single**   | Single regions are used for code which needs to be executed only by a single thread, such as for I/O operations. The first thread to reach the region will execute the code, whilst the other threads will behave as if they've reached a barrier until the executing thread is finished.      | `#pragma omp single`   |
+| **master**   | A master region is identical to the single region other than that execution is done by the designated master thread (usually thread 0).                                                                                                                                                        | `#pragma omp master`   |
 
-The next example builds on the previous example which included a lookup table. In the the modified code, the lookup
+The next example builds on the previous example which included a lookup table. In the modified code, the lookup
 table is written to disk after it has been initialised. This happens in a single region, as only one thread needs to
-write the result to disk.
+write the result to disk (See the full code [here](code/examples/04-single-region.c)).
 
 ```c
 #pragma omp parallel
@@ -216,11 +230,22 @@ write the result to disk.
 }
 ```
 
-If we wanted to sum up something in parallel (e.g. a reduction operation), we need to use a critical region to prevent a
-race condition when a threads is updating the reduction variable. For example, the code used in a previous exercise to
-demonstrate a race condition can be fixed as such,
+:::callout{variant='note'}
+OpenMP has a restriction: you cannot use `#pragma omp single` or `#pragma omp master` directly inside a `#pragma omp parallel for` 
+loop. If you attempt this, you'll encounter an error because OpenMP does not allow these regions to be **"closely nested"** 
+within a parallel loop. However, there’s a useful workaround: move the `single` or `master` region into a separate function 
+and call that function from within the loop. This approach works because OpenMP allows these regions when they are not 
+explicitly part of the loop structure
+:::
+
+If we wanted to sum up something in parallel (e.g., a reduction operation like summing an array), we would need to use a 
+critical region to prevent a race condition when threads update the reduction variable-the shared variable that stores 
+the final result. In the 'Identifying Race Conditions' challenge earlier, we saw that multiple threads 
+updating the same variable (**value**) at the same time caused inconsistencies—a classic race condition. 
+This problem can be fixed by using a critical region, which allows threads to update **value** one at a time. For example:
 
 ```c
+
 int value = 0;
 #pragma omp parallel for
 for (int i = 0; i < NUM_TIMES; ++i) {
@@ -231,24 +256,57 @@ for (int i = 0; i < NUM_TIMES; ++i) {
 }
 ```
 
-As we've added the critical region, only one thread can access and increment `value` at one time. This prevents the race
-condition from earlier, because multiple threads no longer are able to read (and modify) the same variable before
-other threads have finished with it. However in reality we shouldn't write a reduction like this, but would use the
-[reduction
-clause](https://www.intel.com/content/www/us/en/docs/advisor/user-guide/2023-0/openmp-reduction-operations.html) in the
-`parallel for` directive, e.g. `#pragma omp parallel for reduction(+:value)`
+However, while this approach eliminates the race condition, it introduces synchronisation overhead. 
+For lightweight operations like summing values, this overhead can outweigh the benefits of parallelisation.
+
+:::callout
+
+### Reduction Clauses
+
+A more efficient way to handle tasks like summing values is to use OpenMP's `reduction` clause. 
+Unlike the critical region approach, the `reduction` clause avoids explicit synchronisation by 
+allowing each thread to work on its own private copy of the variable. Once the loop finishes, 
+OpenMP combines these private copies into a single result. This not only simplifies the code but also avoids delays 
+caused by threads waiting to access the shared variable.
+
+For example, instead of using a critical region to sum values, we can rewrite the code with a `reduction` clause 
+as shown below:
+
+```c
+#include <omp.h>
+#include <stdio.h>
+
+#define NUM_TIMES 10000
+
+int main() {
+    int value = 0;
+
+    #pragma omp parallel for reduction(+:value)
+    for (int i = 0; i < NUM_TIMES; ++i) {
+        value += 1;
+    }
+
+    printf("Final value: %d\n", value);
+
+    return 0;
+}
+
+```
+Here, the `reduction(+:value)` directive does the work for us. During the loop, each thread maintains its 
+own copy of value, avoiding any chance of a race condition. When the loop ends, OpenMP automatically sums 
+up the private copies into the shared variable value. This means the output will always be correct—in this case, **10000**.
+:::
 
 ::::challenge{id=reportingprogress, title="Reporting progress"}
-
-Create a program that updates a shared counter to track the progress of a parallel loop. Think about which type of
-synchronisation region you can use. Can you think of any potential problems with your implementation, what happens
-when you use different loop schedulers? You can use the code example below as your starting point.
-
-NB: To compile this you’ll need to add `-lm` to inform the linker to link to the math C library, e.g.
-
-```bash
-gcc counter.c -o counter -fopenmp -lm
-```
+The code below attempts to track the progress of a parallel loop using a shared counter, `progress`. 
+However, it has a problem: the final value of progress is often incorrect, and the progress updates might be 
+inconsistent.
+- Can you identify the issue with the current implementation?
+- How would you fix it to ensure the progress counter works correctly and updates are synchronised?
+- After fixing the issue, experiment with different loop schedulers (`static`, `dynamic`, `guided` and `auto`) 
+to observe how they affect progress reporting.
+    - What changes do you notice in the timing and sequence of updates when using these schedulers?
+    - Which scheduler produces the most predictable progress updates?
 
 ```c
 #include <math.h>
@@ -258,59 +316,120 @@ gcc counter.c -o counter -fopenmp -lm
 
 int main(int argc, char **argv) {
     int array[NUM_ELEMENTS] = {0};
+    int progress = 0;
 
     #pragma omp parallel for schedule(static)
     for (int i = 0; i < NUM_ELEMENTS; ++i) {
         array[i] = log(i) * cos(3.142 * i);
+
+        progress++;
     }
 
+    printf("Final progress: %d (Expected: %d)\n", progress, NUM_ELEMENTS);
     return 0;
 }
 ```
+NB: To compile this you’ll need to add `-lm` to inform the linker to link to the math C library, e.g.
+
+```bash
+gcc counter.c -o counter -fopenmp -lm
+```
 
 :::solution
+The above program tracks progress using a shared counter (`progress++`) inside the loop, 
+but it does so without synchronisation, leading to a race condition. 
+Since multiple threads can access and modify progress at the same time, the final value of progress will likely be incorrect. 
+This happens because the updates to progress are not synchronised across threads. As a result, the final value of 
+`progress` is often incorrect and varies across runs. You might see output like this:
 
-To implement a progress bar, we have created two new variables: `progress` and `output_frequency`. We use `progress`
-to track the number of iterations completed across all threads. To prevent a race condition, we increment progress
-in a critical region. In the same critical region, we print the progress report out to screen whenever `progress` is
-divisible by `output_frequency`.
+```text
+Final progress: 9983 (Expected: 10000)
+```
+
+To fix this issue, we use a critical region to synchronise updates to progress. 
+We also introduce a second variable, `output_frequency`, to control how often progress updates are reported 
+(e.g., every 10% of the total iterations).
+
+The corrected version:
 
 ```c
 #include <math.h>
 #include <omp.h>
 #include <stdio.h>
 
-#define NUM_ELEMENTS 1000
+#define NUM_ELEMENTS 10000
 
 int main(int argc, char **argv) {
     int array[NUM_ELEMENTS] = {0};
-
     int progress = 0;
-    int output_frequency = NUM_ELEMENTS / 10; /* output every 10% */
+    int output_frequency = NUM_ELEMENTS / 10; /* Output progress every 10% */
 
     #pragma omp parallel for schedule(static)
     for (int i = 0; i < NUM_ELEMENTS; ++i) {
         array[i] = log(i) * cos(3.142 * i);
 
-    #pragma omp critical
-    {
-         progress++;
-         if (progress % output_frequency == 0) {
-             int thread_id = omp_get_thread_num();
-             printf("Thread %d: overall progress %3.0f%%\n", thread_id,
-                    (double)progress / NUM_ELEMENTS * 100.0);
-       }
+        /* Update progress counter (with synchronisation) */
+        #pragma omp critical
+        {
+            progress++;
+            if (progress % output_frequency == 0) {
+                printf("Progress: %d%%\n", (progress * 100) / NUM_ELEMENTS);
+            }
+        }
     }
- }
 
- return 0;
+    printf("Final progress: %d (Expected: %d)\n", progress, NUM_ELEMENTS);
+    return 0;
 }
 ```
+This implementation resolves the race condition by ensuring that only one thread can modify progress at a time. 
+However, this solution comes at a cost: **synchronisation overhead**. Every iteration requires threads to enter the 
+critical region, and if the loop body is lightweight (e.g., simple calculations), this overhead may outweigh the 
+computational benefits of parallelisation. For example, if each iteration takes only a few nanoseconds to compute, 
+the time spent waiting for access to the critical region might dominate the runtime.
 
-One problem with this implementation is that tracking progress like this introduces a synchronisation overhead at
-the end of each iteration, because of the critical region. In small loops like this, there's usually no reason to
-track progress as the synchronisation overheads could be more significant than the time required to calculate each
-array element!
+### Behaviour with different schedulers
+
+The static scheduler, used in the corrected version, divides iterations evenly among threads. This ensures predictable 
+and consistent progress updates. For instance, progress increments occur at regular intervals (e.g., 10%, 20%, etc.), 
+producing output like:
+
+```
+Progress: 10%
+Progress: 20%
+Progress: 30%
+...
+Final progress: 10000 (Expected: 10000)
+```
+
+When experimenting with other schedulers, such as `dynamic` or `guided`, 
+the timing and sequence of updates change due to differences in how iterations are assigned to threads.
+
+With the `dynamic` scheduler, threads are assigned smaller chunks of iterations as they finish their current work. 
+This can lead to progress updates appearing irregular, as threads complete their chunks at varying speeds based on 
+workload. For example:
+
+```
+Progress: 15%
+Progress: 30%
+Progress: 55%
+...
+Final progress: 10000 (Expected: 10000)
+```
+Using the `guided` scheduler results in yet another pattern. Threads start with larger chunks of iterations, 
+and the chunk size decreases as the loop progresses. This often leads to progress updates being sparse at the start but 
+becoming more frequent toward the end of the loop:
+
+```
+Progress: 25%
+Progress: 70%
+Progress: 100%
+Final progress: 10000 (Expected: 10000)
+```
+The `auto` scheduler, on the other hand, leaves the decision about iteration assignment to the OpenMP runtime system. 
+This provides flexibility, as the runtime adapts the scheduling to optimise for the specific platform and workload. 
+However, because `auto` is implementation-dependent, the timing and predictability of progress updates can vary and 
+are harder to generalise.
 :::
 ::::
 
@@ -318,8 +437,8 @@ array element!
 
 A large amount of the time spent writing a parallel OpenMP application is usually spent preventing race conditions,
 rather than on the parallelisation itself. Earlier in the episode, we looked at critical regions as a way to synchronise
-threads and explored how be used to prevent race conditions in the previous exercise. In the rest of this section, we
-will look at the other mechanisms which can prevent race conditions, namely by setting locks or by using atomic
+threads and explored how they can be used to prevent race conditions in the previous exercise. In the rest of this section, we
+will look at the other mechanisms which can prevent race conditions, such as setting locks or using atomic
 operations.
 
 ### Locks
@@ -328,14 +447,14 @@ Critical regions provide a convenient and straightforward way to synchronise thr
 race conditions. But in some cases, critical regions may not be flexible or granular enough and lead to an excessive
 amount of serialisation. If this is the case, we can use *locks* instead to achieve the same effect as a critical
 region. Locks are a mechanism in OpenMP which, just like a critical regions, create regions in our code which only one
-thread can be in at one time. The main advantage of locks, over a critical region, is that we can be far more flexible
-with locks to protect different sized or fragmented regions of code, giving us more granular control over thread
-synchronisation. Locks are also far more flexible when it comes to making our code more modular, as it is possible to
+thread can be in at one time. The main advantage of locks, compared to critical regions, is that they provide more
+granular control over thread synchronisation by protecting different-sized or fragmented regions of code, therefore 
+allowing greater flexibility. Locks are also far more flexible when it comes to making our code more modular, as it is possible to
 nest locks, or for accessing and modifying global variables.
 
 In comparison to critical regions, however, locks are more complicated and difficult to use. Instead of using a single
 `#pragma`, we have to initialise and free resources used for the locks, as well as set and unset where locks are in
-effect. If we make a mistake and forget to unset a lock, then we lose all of the parallelism and could potentially
+effect. If we make a mistake and forget to unset a lock, then we lose all the parallelism and could potentially
 create a deadlock!
 
 To create a lock and delete a lock, we use `omp_init_lock()` and `omp_destroy_lock()` respectively.
@@ -389,36 +508,47 @@ forget to or unset a lock in the wrong place.
 
 ### Atomic operations
 
-Another mechanism are atomic operations. In computing, an atomic operation is an operation which is performed without
-interrupted, meaning that one initiated, they are guaranteed to execute without interference from other operations. In
-OpenMP, this means atomic operations are operations which are done without interference from other threads. If we make
-modifying some value in an array atomic, then it's guaranteed, by the compiler, that no other thread can read or modify
-that array until the atomic operation is finished. You can think of it as a thread having, temporary, exclusive access
-to something in our program. Sort of like a "one at a time" rule for accessing and modifying parts of the program.
+Another mechanism is atomic operations. In computing, an atomic operation is an operation which is performed without
+interruption, meaning that once initiated, it is guaranteed to execute without interference from other operations. 
+In OpenMP, this refers to operations that execute without interference from other threads. If we make an operation modifying a value in 
+an array atomic, the compiler guarantees that no other thread can read or modify that array until the atomic operation is 
+finished. You can think of it as a thread having temporary exclusive access to something in our program, similar to a 
+'one at a time' rule for accessing and modifying parts of the program.
 
 To do an atomic operation, we use the `omp atomic` pragma before the operation we want to make atomic.
 
 ```c
-int shared_variable = 0;
-int shared_array[4] = {0, 0, 0, 0};
+#include <stdio.h>
+#include <omp.h>
 
-/* Put the pragma before the shared variable */
-#pragma omp parallel
-{
-    #pragma omp atomic
-    shared_variable += 1;
+int main() {
+
+  int shared_variable = 0;
+  int shared_array[4] = {0, 0, 0, 0};
+
+  /* Put the pragma before the shared variable */
+  #pragma omp parallel
+  {
+  	#pragma omp atomic
+  	shared_variable += 1;
+  	printf("Shared variable updated: %d\n", shared_variable);
+  }
+
+  /* Can also use in a parallel for */
+  #pragma omp parallel for
+  for (int i = 0; i < 4; ++i) {
+  	#pragma omp atomic
+  	shared_array[i] += 1;
+  	printf("Shared array element %d updated: %d\n", i, shared_array[i]);
+
+  }
+
 }
 
-/* Can also use in a parallel for */
-#pragma omp parallel for
-for (int i = 0; i < 4; ++i) {
-    #pragma omp atomic
-    shared_array[i] += 1;
-}
 ```
 
 Atomic operations are for single line operations or piece of code. As in the example above, we can do an atomic
-operation when we are updating variable but we can also do other things such as atomic assignment. Atomic operations are
+operation when we are updating variable, but we can also do other things such as atomic assignment. Atomic operations are
 often less expensive than critical regions or locks, so they should be preferred when they can be used. However, it's
 still important to not be over-zealous with using atomic operations as they can still introduce synchronisation
 overheads which can damage the parallel performance.
@@ -439,7 +569,8 @@ Critical regions and locks are more appropriate when:
 
 Atomic operations are good when:
 
-- The operation which needs synchronisation is simple, such as needing to protect a single variable update in the parallel algorithm.
+- The operation which needs synchronisation is simple, such as needing to protect a single variable update in the parallel 
+algorithm.
 - There is low contention for shared data.
 - When you need to be as performant as possible, as atomic operations generally have the lowest performance cost.
 
@@ -483,7 +614,7 @@ int main(int argc, char **argv) {
 When we run the program multiple times, we expect the output `sum` to have the value of `0.000000`. However, due to an
 existing race condition, the program can sometimes produce wrong output in different runs, as shown below:
 
-```text
+```
 1. Sum: 1.000000
 2. Sum: -1.000000
 3. Sum: 2.000000
@@ -491,7 +622,7 @@ existing race condition, the program can sometimes produce wrong output in diffe
 5. Sum: 2.000000
 ```
 
-Find and fix the race condition in the program. Try using both an atomic operation and by using locks.
+Find and fix the race condition in the program using both an atomic operation and locks.
 
 :::solution
 

--- a/high_performance_computing/hpc_openmp/05_hybrid_parallelism.md
+++ b/high_performance_computing/hpc_openmp/05_hybrid_parallelism.md
@@ -58,7 +58,7 @@ the data that threads in another MPI process have access to due to each MPI proc
 still possible to communicate thread-to-thread, but we have to be very careful and explicitly set up communication
 between specific threads using the parent MPI processes.
 
-As an example of how resources could be split using an MPI+OpenMP approach, consider a HPC cluster with some number of
+As an example of how resources could be split using an MPI+OpenMP approach, consider an HPC cluster with some number of
 compute nodes with each having 64 CPU cores. One approach would be to spawn one MPI process per rank which spawns 64
 OpenMP threads, or 2 MPI processes which both spawn 32 OpenMP threads, and so on and so forth.
 
@@ -66,7 +66,7 @@ OpenMP threads, or 2 MPI processes which both spawn 32 OpenMP threads, and so on
 
 #### Improved memory efficiency
 
-Since MPI processes each have their own private memory space, there is almost aways some data replication. This could be
+Since MPI processes each have their own private memory space, there is almost always some data replication. This could be
 on small pieces of data, such as some physical constants each MPI rank needs, or it could be large pieces of data such a
 grid of data or a large dataset. When there is large data being replicated in each rank, the memory requirements of an
 MPI program can rapidly increase making it unfeasible to run on some systems. In an OpenMP application, we don't have to
@@ -82,7 +82,7 @@ can more easily control the work balance, in comparison to a pure MPI implementa
 schedulers to address imbalance on a node. There is typically also a reduction in communication overheads, as there is
 no communication required between threads (although this overhead may be replaced by thread synchronisation overheads)
 which can improve the performance of algorithms which previously required communication such as those which require
-exchanging data between overlapping sub-domains (halo exchange).
+exchanging data between overlapping subdomains (halo exchange).
 
 ### Disadvantages
 
@@ -90,7 +90,7 @@ exchanging data between overlapping sub-domains (halo exchange).
 
 Writing *correct* and efficient parallel code in pure MPI and pure OpenMP is hard enough, so combining both of them is,
 naturally, even more difficult to write and maintain. Most of the difficulty comes from having to combine both
-parallelism models in an easy to read and maintainable fashion, as the interplay between the two parallelism models adds
+parallelism models in an easy-to-read and maintainable fashion, as the interplay between the two parallelism models adds
 complexity to the code we write. We also have to ensure we do not introduce any race conditions, making sure to
 synchronise threads and ranks correctly and at the correct parts of the program. Finally, because we are using two
 parallelism models, MPI+OpenMP code bases are larger than a pure MPI or OpenMP version, making the overall
@@ -114,13 +114,13 @@ Most of this can, however, be mitigated with good documentation and a robust bui
 
 So, when should we use a hybrid scheme? A hybrid scheme is particularly beneficial in scenarios where you need to
 leverage the strength of both the shared and distributed-memory parallelism paradigms. MPI is used to exploit lots of
-resources across nodes on a HPC cluster, whilst OpenMP is used to efficiently (and somewhat easily) parallelise the work
+resources across nodes on an HPC cluster, whilst OpenMP is used to efficiently (and somewhat easily) parallelise the work
 each MPI task is required to do.
 
 The most common reason for using a hybrid scheme is for large-scale simulations, where the workload doesn't fit or work
 efficiently in a pure MPI or OpenMP implementation. This could be because of memory constraints due to data replication,
 or due to poor/complex workload balance which are difficult to handle in MPI, or because of inefficient data access
-patterns from how ranks are coordinated. Of course, your mileage may vary and it is not always appropriate to use a
+patterns from how ranks are coordinated. Of course, your mileage may vary, and it is not always appropriate to use a
 hybrid scheme. It could be better to think about other ways or optimisations to decrease overheads and memory
 requirements, or to take a different approach to improve the work balance.
 
@@ -134,12 +134,12 @@ parallelised. Specifically, we will write a program to solve the integral to com
 $$ \int_{0}^{1} \frac{4}{1 + x^{2}} ~ \mathrm{d}x = 4 \tan^{-1}(x) = \pi $$
 
 There are a plethora of methods available to numerically evaluate this integral. To keep the problem simple, we will
-re-cast the integral into a easier-to-code summation. How we got here isn't that important for our purposes, but what we
+re-cast the integral into an easier-to-code summation. How we got here isn't that important for our purposes, but what we
 will be implementing in code is the following summation,
 
 $$ \pi = \lim_{n \to \infty} \sum_{i = 0}^{n} \frac{1}{n} ~ \frac{4}{1 + x_{i}^{2}} $$
 
-where $x_{i}$ is the the midpoint of the $i$-th rectangle. To get an accurate approximation of $\pi$, we'll need to
+where $x_{i}$ is the midpoint of the $i$-th rectangle. To get an accurate approximation of $\pi$, we'll need to
 split the domain into a large number of smaller rectangles.
 
 ### A simple parallel implementation using OpenMP
@@ -196,7 +196,7 @@ Calculated pi           3.141593 error           0.000000
 Total time = 34.826832 seconds
 ```
 
-You should see that we've compute an accurate approximation of $\pi$, but it also took a very long time at 35 seconds!
+You should see that we've computed an accurate approximation of $\pi$, but it also took a very long time at 35 seconds!
 To speed this up, let's first parallelise this using OpenMP. All we need to do, for this simple application, is to use a
 `parallel for` to split the loop between OpenMP threads as shown below.
 
@@ -231,9 +231,9 @@ Total time = 5.166490 seconds
 ### A hybrid implementation using MPI and OpenMP
 
 Now that we have a working parallel implementation using OpenMP, we can now expand our code to a hybrid parallel code by
-implementing MPI. In this example, we can porting an OpenMP code to a hybrid MPI+OpenMP application but we could have
+implementing MPI. In this example, we wil be porting an OpenMP code to a hybrid MPI+OpenMP application, but we could have
 also done this the other way around by porting an MPI code into a hybrid application. Neither *"evolution"* is more
-common or better than the other, the route each code takes toward becoming hybrid is different.
+common nor better than the other, the route each code takes toward becoming hybrid is different.
 
 So, how do we split work using a hybrid approach? For an embarrassingly parallel problem, such as the one we're working on, 
 we can split the problem size into smaller chunks across MPI ranks and use OpenMP to parallelise the work. For example, consider 
@@ -378,8 +378,8 @@ Total time = 5.818889 seconds
 Ouch, this took longer to run than the pure OpenMP implementation (although only marginally longer in this example!). You
 may have noticed that we have 8 MPI ranks, each of which are spawning 8 of their own OpenMP threads. This is an
 important thing to realise. When you specify the number of threads for OpenMP to use, this is the number of threads
-*each* MPI process will spawn. So why did it take longer? With each of the 8 MPI ranks spawning 8 threads, 64 threads
-threads were in flight. More threads means more overheads and if, for instance, we have 8 CPU Cores, then contention
+*each* MPI process will spawn. So why did it take longer? With each of the 8 MPI ranks spawning 8 threads, 64 threads 
+were in flight. More threads means more overheads and if, for instance, we have 8 CPU Cores, then contention
 arises as each thread competes for access to a CPU core.
 
 Let's improve this situation by using a combination of rank and threads so that $N_{\mathrm{ranks}} N_{\mathrm{threads}}

--- a/high_performance_computing/hpc_openmp/code/examples/04-barriers.c
+++ b/high_performance_computing/hpc_openmp/code/examples/04-barriers.c
@@ -1,0 +1,42 @@
+#include <omp.h>
+#include <stdio.h>
+
+#define TABLE_SIZE 8
+
+/* Function to initialise the lookup table */
+void initialise_lookup_table(int thread_id, double lookup_table[TABLE_SIZE]) {
+    int num_threads = omp_get_num_threads();
+    for (int i = thread_id; i < TABLE_SIZE; i += num_threads) {
+        lookup_table[i] = thread_id * 2; /* Each thread initialises its own portion */
+        printf("Thread %d initializing lookup_table[%d] = %f\n", thread_id, i, lookup_table[i]);
+    }
+}
+
+/* Function to perform the main calculation */
+void do_main_calculation(int thread_id, double lookup_table[TABLE_SIZE]) {
+    int num_threads = omp_get_num_threads();
+    for (int i = thread_id; i < TABLE_SIZE; i += num_threads) {
+        printf("Thread %d processing lookup_table[%d] = %f\n", thread_id, i, lookup_table[i]);
+    }
+}
+
+int main() {
+    double lookup_table[TABLE_SIZE] = {0}; /* Initialise the lookup table to zeros */
+
+    #pragma omp parallel
+    {
+        int thread_id = omp_get_thread_num();
+
+        /* The initialisation of the lookup table is done in parallel */
+        initialise_lookup_table(thread_id, lookup_table);
+
+        #pragma omp barrier  /* As all threads depend on the table, we have to wait until all threads
+                            are done and have reached the barrier */
+
+
+        /* Each thread then proceeds to its main calculation */
+        do_main_calculation(thread_id, lookup_table);
+    }
+
+    return 0;
+}

--- a/high_performance_computing/hpc_openmp/code/examples/04-barriers.c
+++ b/high_performance_computing/hpc_openmp/code/examples/04-barriers.c
@@ -16,6 +16,7 @@ void initialise_lookup_table(int thread_id, double lookup_table[TABLE_SIZE]) {
 void do_main_calculation(int thread_id, double lookup_table[TABLE_SIZE]) {
     int num_threads = omp_get_num_threads();
     for (int i = thread_id; i < TABLE_SIZE; i += num_threads) {
+        lookup_table[i] = lookup_table[i] * 5.0;
         printf("Thread %d processing lookup_table[%d] = %f\n", thread_id, i, lookup_table[i]);
     }
 }

--- a/high_performance_computing/hpc_openmp/code/examples/04-matrix-update.c
+++ b/high_performance_computing/hpc_openmp/code/examples/04-matrix-update.c
@@ -1,0 +1,41 @@
+#include <omp.h>
+#include <stdio.h>
+
+#define NX 4
+#define NY 4
+#define NUM_ITERATIONS 10
+
+void iterate_matrix_solution(double old_matrix[NX][NY], double new_matrix[NX][NY], int thread_id) {
+    for (int j = 0; j < NY; ++j) {
+        new_matrix[thread_id][j] = old_matrix[thread_id][j] + 1;
+    }
+}
+
+void copy_matrix(double src[NX][NY], double dest[NX][NY]) {
+    for (int i = 0; i < NX; ++i) {
+        for (int j = 0; j < NY; ++j) {
+            dest[i][j] = src[i][j];
+        }
+    }
+}
+
+int main() {
+    double old_matrix[NX][NY] = {{0}};
+    double new_matrix[NX][NY] = {{0}};
+
+    #pragma omp parallel
+    {
+        for (int i = 0; i < NUM_ITERATIONS; ++i) {
+            int thread_id = omp_get_thread_num();
+
+            iterate_matrix_solution(old_matrix, new_matrix, thread_id); /* Each thread updates a portion of the matrix */
+
+            #pragma omp barrier /* Wait until all threads complete updates to new_matrix */
+
+            copy_matrix(new_matrix, old_matrix);
+        }
+    }
+
+    printf("Matrix update complete.\n");
+    return 0;
+}

--- a/high_performance_computing/hpc_openmp/code/examples/04-single-region.c
+++ b/high_performance_computing/hpc_openmp/code/examples/04-single-region.c
@@ -1,0 +1,49 @@
+#include <omp.h>
+#include <stdio.h>
+
+#define TABLE_SIZE 8
+
+
+void initialise_lookup_table(int thread_id, double lookup_table[TABLE_SIZE]) {
+    int num_threads = omp_get_num_threads();
+    for (int i = thread_id; i < TABLE_SIZE; i += num_threads) {
+        lookup_table[i] = thread_id * 2;
+        printf("Thread %d initializing lookup_table[%d] = %f\n", thread_id, i, lookup_table[i]);
+    }
+}
+
+
+void write_table_to_disk(double lookup_table[TABLE_SIZE]) {
+    printf("Writing lookup table to disk:\n");
+    for (int i = 0; i < TABLE_SIZE; ++i) {
+        printf("lookup_table[%d] = %f\n", i, lookup_table[i]);
+    }
+}
+
+
+void do_main_calculation(int thread_id) {
+    printf("Thread %d performing its main calculation.\n", thread_id);
+}
+
+int main() {
+    double lookup_table[TABLE_SIZE] = {0};
+
+    #pragma omp parallel
+    {
+        int thread_id = omp_get_thread_num();
+
+
+        initialise_lookup_table(thread_id, lookup_table);
+
+        #pragma omp barrier
+
+        #pragma omp single
+        {
+            write_table_to_disk(lookup_table);
+        }
+
+        do_main_calculation(thread_id);
+    }
+
+    return 0;
+}

--- a/high_performance_computing/hpc_openmp/code/solutions/04-race-condition-lock.c
+++ b/high_performance_computing/hpc_openmp/code/solutions/04-race-condition-lock.c
@@ -5,29 +5,31 @@
 #define ARRAY_SIZE 524288
 
 int main(int argc, char **argv) {
-  float sum = 0;
-  float array[ARRAY_SIZE];
+    float sum = 0;
+    float array[ARRAY_SIZE];
 
-  omp_set_num_threads(4);
+    omp_set_num_threads(4);
 
-#pragma omp parallel for schedule(static)
-  for (int i = 0; i < ARRAY_SIZE; ++i) {
-    array[i] = cos(M_PI * i);
-  }
+    #pragma omp parallel for schedule(static)
+    for (int i = 0; i < ARRAY_SIZE; ++i) {
+        array[i] = cos(M_PI * i);
+    }
 
-  omp_lock_t lock;
-  omp_init_lock(&lock);
+    omp_lock_t lock;
+    omp_init_lock(&lock);
 
-#pragma omp parallel for schedule(static)
-  for (int i = 0; i < ARRAY_SIZE; i++) {
-    omp_set_lock(&lock);
-    sum += array[i];
-    omp_unset_lock(&lock);
-  }
 
-  printf("Sum: %f\n", sum);
+    #pragma omp parallel for schedule(static)
+    for (int i = 0; i < ARRAY_SIZE; i++) {
+        omp_set_lock(&lock);
+        sum += array[i];
+        omp_unset_lock(&lock);
+    }
 
-  omp_destroy_lock(&lock);
 
-  return 0;
+    printf("Sum: %f\n", sum);
+
+    omp_destroy_lock(&lock);
+
+    return 0;
 }


### PR DESCRIPTION
### Episode 2 - Intro OpenMP
- Fixed typos
- Added a note about `<omp.h>` usage

### Episode 3 - Parallelisation with OpenMP
- Corrected typos .
- Clarified the concept of private variables with additional explanation.
- Added a callout box about nested loops and the `collapse` clause.
- Expanded the progress counter example, addressing race condition concerns.
- Enhanced the atomic section with compilable example code.
- Added a new callout section for reduction clauses with examples.
- Included lines about restrictions on nested regions in the barriers section.

### Episode 4 - Synchronisation and Race Conditions 
- Provided a stand alone example code for race conditions.
- Replaced non-defined functions with fully defined  code examples
- Corrected indentation in the solution for `04-race-condition-lock.c`.
- Added more context to the explanation of thread-specific matrix updates.
- Updated synchronisation routine examples 

### Episode 5 - Introduction to Hybrid Parallelism
- Fixed typos.

